### PR TITLE
Sprint2 - Add Room entity and migration

### DIFF
--- a/src/Domain/VidSync.Domain/Entities/Room.cs
+++ b/src/Domain/VidSync.Domain/Entities/Room.cs
@@ -1,0 +1,10 @@
+namespace VidSync.Domain.Entities;
+
+public class Room
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public DateTime CreatedAt { get; set; }
+    public DateTime? ExpiresAt { get; set; }
+    public bool IsActive { get; set; }
+}

--- a/src/Infrastructure/VidSync.Persistence/AppDbContext.cs
+++ b/src/Infrastructure/VidSync.Persistence/AppDbContext.cs
@@ -13,10 +13,12 @@ public class AppDbContext : IdentityDbContext<User, IdentityRole<Guid>, Guid>
     }
 
     public DbSet<User> Users { get; set; } = null!;
+    public DbSet<Room> Rooms { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
+
         modelBuilder.Entity<User>(entity =>
         {
             entity.ToTable("Users");
@@ -26,6 +28,16 @@ public class AppDbContext : IdentityDbContext<User, IdentityRole<Guid>, Guid>
             entity.Property(e => e.LastName).IsRequired(true).HasMaxLength(50);
             entity.Property(e => e.ProfilePictureUrl).IsRequired(false).HasMaxLength(256).HasDefaultValue("https://img.freepik.com/free-vector/blue-circle-with-white-user_78370-4707.jpg?semt=ais_hybrid&w=740");
             entity.Property(e => e.CreatedAt).IsRequired(true).HasColumnType("timestamp with time zone").HasDefaultValueSql("NOW()");
+        });
+
+        modelBuilder.Entity<Room>(entity =>
+        {
+            entity.ToTable("Rooms");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Name).IsRequired(true).HasMaxLength(100);
+            entity.Property(e => e.CreatedAt).IsRequired(true).HasColumnType("timestamp with time zone").HasDefaultValueSql("NOW()");
+            entity.Property(e => e.ExpiresAt).IsRequired(false).HasColumnType("timestamp with time zone");
+            entity.Property(e => e.IsActive).IsRequired(true).HasDefaultValue(true);
         });
     }
 }

--- a/src/Infrastructure/VidSync.Persistence/Migrations/20250914060121_AddRoomEntity.Designer.cs
+++ b/src/Infrastructure/VidSync.Persistence/Migrations/20250914060121_AddRoomEntity.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VidSync.Persistence;
@@ -11,9 +12,11 @@ using VidSync.Persistence;
 namespace VidSync.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250914060121_AddRoomEntity")]
+    partial class AddRoomEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/VidSync.Persistence/Migrations/20250914060121_AddRoomEntity.cs
+++ b/src/Infrastructure/VidSync.Persistence/Migrations/20250914060121_AddRoomEntity.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VidSync.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRoomEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Rooms",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "NOW()"),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Rooms", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Rooms");
+        }
+    }
+}


### PR DESCRIPTION
Introduced the Room entity to the domain model and updated AppDbContext to include Rooms. Added EF Core migration to create the Rooms table with relevant properties and constraints.