### PR TITLE
Sprint3 - Some Adjustments Were Made to Ensure Healthy Testing on the Local Network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,4 @@ CodeCoverage/
 TestResult.xml
 nunit-*.xml
 
-.vs/
+*.p12

--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,5 @@ CodeCoverage/
 TestResult.xml
 nunit-*.xml
 
+.vs/
 *.p12

--- a/src/Core/VidSync.API/Controllers/TestController.cs
+++ b/src/Core/VidSync.API/Controllers/TestController.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace VidSync.API.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class TestController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Get()
+        {
+            return Ok("API is working!");
+        }
+    }
+}

--- a/src/Core/VidSync.API/Program.cs
+++ b/src/Core/VidSync.API/Program.cs
@@ -17,7 +17,15 @@ builder.Services.AddCors(options =>
     options.AddPolicy(name: MyAllowSpecificOrigins,
                       policy =>
                       {
-                          policy.WithOrigins("http://localhost:5173", "http://192.168.1.157:5173")
+                            policy.WithOrigins(
+                                // Localhost adresleri
+                                "http://localhost:5173", 
+                                "https://localhost:5173",
+
+                                // IP adresleri
+                                "http://192.168.1.157:5173",
+                                "https://192.168.1.157:5173"
+                              )
                                 .AllowAnyHeader()
                                 .AllowAnyMethod()
                                 .AllowCredentials();

--- a/src/Core/VidSync.API/Program.cs
+++ b/src/Core/VidSync.API/Program.cs
@@ -10,14 +10,14 @@ using System.Security.Claims;
 
 var builder = WebApplication.CreateBuilder(args);
 
-var MyAllowSpecificOrigins = "http://localhost:5173";
+var MyAllowSpecificOrigins = "_myAllowSpecificOrigins";
 
 builder.Services.AddCors(options =>
 {
     options.AddPolicy(name: MyAllowSpecificOrigins,
                       policy =>
                       {
-                          policy.WithOrigins("http://localhost:5173")
+                          policy.WithOrigins("http://localhost:5173", "http://192.168.1.157:5173")
                                 .AllowAnyHeader()
                                 .AllowAnyMethod()
                                 .AllowCredentials();

--- a/src/Core/VidSync.API/Program.cs
+++ b/src/Core/VidSync.API/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using VidSync.Signaling.Hubs;
 using System.Security.Claims;
+using System.Net;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -94,11 +95,19 @@ builder.Services.AddAuthentication(options =>
 });
 
 builder.Services.AddSignalR();
-
 builder.Services.AddAuthorization();
-
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(); 
+
+builder.WebHost.ConfigureKestrel(serverOptions =>
+{
+    serverOptions.Listen(System.Net.IPAddress.Any, 5123);
+
+    serverOptions.Listen(System.Net.IPAddress.Any, 7123, listenOptions =>
+    {
+        listenOptions.UseHttps("localhost+3.p12", "changeit"); 
+    });
+});
 
 var app = builder.Build();
 
@@ -109,12 +118,10 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseRouting();
-
 app.UseCors(MyAllowSpecificOrigins);
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
-
 app.MapHub<CommunicationHub>("/communicationhub");
 
 app.Run();

--- a/src/Core/VidSync.API/Program.cs
+++ b/src/Core/VidSync.API/Program.cs
@@ -101,9 +101,9 @@ builder.Services.AddSwaggerGen();
 
 builder.WebHost.ConfigureKestrel(serverOptions =>
 {
-    serverOptions.Listen(System.Net.IPAddress.Any, 5123);
+    serverOptions.Listen(IPAddress.Any, 5123);
 
-    serverOptions.Listen(System.Net.IPAddress.Any, 7123, listenOptions =>
+    serverOptions.Listen(IPAddress.Any, 7123, listenOptions =>
     {
         listenOptions.UseHttps("localhost+3.p12", "changeit"); 
     });

--- a/src/Core/VidSync.API/Properties/launchSettings.json
+++ b/src/Core/VidSync.API/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "https://localhost:7123;https://192.168.1.157:7123;http://localhost:5166;http://192.168.1.157:5166;http://0.0.0.0:5166",
+      "applicationUrl": "https://0.0.0.0:7123;http://0.0.0.0:5166;http://localhost:5166",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/Core/VidSync.API/Properties/launchSettings.json
+++ b/src/Core/VidSync.API/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:5166",
+      "applicationUrl": "https://localhost:7123;https://192.168.1.157:7123;http://localhost:5166;http://192.168.1.157:5166;http://0.0.0.0:5166",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/Core/VidSync.Signaling/Hubs/CommunicationHub.cs
+++ b/src/Core/VidSync.Signaling/Hubs/CommunicationHub.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.SignalR;
 using System.Security.Claims;
 using System.Collections.Concurrent;
 using VidSync.Domain.Entities;
+using System.Threading.Tasks;
 
 namespace VidSync.Signaling.Hubs
 {
@@ -22,12 +23,25 @@ namespace VidSync.Signaling.Hubs
         public async Task JoinRoom(string roomId)
         {
             var userId = Context?.User?.FindFirstValue(ClaimTypes.NameIdentifier);
-            if (string.IsNullOrEmpty(userId)) return;
+            if (string.IsNullOrEmpty(userId))
+            {
+                Console.WriteLine("JoinRoom failed: UserId is null or empty");
+                throw new HubException("UserId is null or empty");
+            }
 
             var currentUser = await _userManager.FindByIdAsync(userId);
-            if (currentUser == null) return;
+            if (currentUser == null)
+            {
+                Console.WriteLine($"JoinRoom failed: User not found for UserId: {userId}");
+                throw new HubException($"User not found for UserId: {userId}");
+            }
 
             var connectionId = Context?.ConnectionId;
+            if (string.IsNullOrEmpty(connectionId))
+            {
+                Console.WriteLine("JoinRoom failed: ConnectionId is null or empty");
+                throw new HubException("ConnectionId is null or empty");
+            }
 
             var otherUserIdsInRoom = ConnectionToUserMap
                 .Where(kvp => kvp.Key != connectionId && ConnectionToRoomMap.ContainsKey(kvp.Key) && ConnectionToRoomMap[kvp.Key] == roomId)
@@ -45,9 +59,9 @@ namespace VidSync.Signaling.Hubs
 
             await Clients.Caller.SendAsync("ExistingParticipants", existingParticipants);
 
-            await Groups.AddToGroupAsync(connectionId ?? string.Empty, roomId);
-            ConnectionToRoomMap[connectionId ?? string.Empty] = roomId;
-            ConnectionToUserMap[connectionId ?? string.Empty] = userId;
+            await Groups.AddToGroupAsync(connectionId, roomId);
+            ConnectionToRoomMap[connectionId] = roomId;
+            ConnectionToUserMap[connectionId] = userId;
 
             await Clients.OthersInGroup(roomId).SendAsync("UserJoined", new
             {
@@ -72,42 +86,98 @@ namespace VidSync.Signaling.Hubs
             await base.OnDisconnectedAsync(exception);
         }
 
-        public async Task SendOffer(string targetuserId, object offer)
+        public async Task SendOffer(string targetUserId, string serializedOffer)
         {
             var callingUserId = Context?.User?.FindFirstValue(ClaimTypes.NameIdentifier);
-            if (string.IsNullOrEmpty(callingUserId)) return;
+            if (string.IsNullOrEmpty(callingUserId))
+            {
+                Console.WriteLine("SendOffer failed: CallingUserId is null or empty");
+                throw new HubException("CallingUserId is null or empty");
+            }
 
-            var targetConnectionId = ConnectionToUserMap.FirstOrDefault(kvp => kvp.Value == targetuserId).Key;
+            if (string.IsNullOrEmpty(targetUserId) || string.IsNullOrEmpty(serializedOffer))
+            {
+                Console.WriteLine($"SendOffer failed: Invalid parameters - targetUserId: {targetUserId}, serializedOffer: {serializedOffer}");
+                throw new HubException($"Invalid parameters - targetUserId: {targetUserId}, serializedOffer: {serializedOffer}");
+            }
+
+            var targetConnectionId = ConnectionToUserMap.FirstOrDefault(kvp => kvp.Value == targetUserId).Key;
             if (!string.IsNullOrEmpty(targetConnectionId))
             {
-                await Clients.Client(targetConnectionId).SendAsync("ReceiveOffer", offer);
-                Console.WriteLine($"Offer sent from {callingUserId} to {targetuserId}");
+                await Clients.Client(targetConnectionId).SendAsync("ReceiveOffer", callingUserId, serializedOffer);
+                Console.WriteLine($"Offer sent from {callingUserId} to {targetUserId}: {serializedOffer}");
+            }
+            else
+            {
+                Console.WriteLine($"SendOffer failed: No connection found for targetUserId: {targetUserId}");
+                throw new HubException($"No connection found for targetUserId: {targetUserId}");
             }
         }
 
-        public async Task SendAnswer(string targetuserId, object answer)
+        public async Task SendAnswer(string targetUserId, string serializedAnswer)
         {
             var callingUserId = Context?.User?.FindFirstValue(ClaimTypes.NameIdentifier);
-            if (string.IsNullOrEmpty(callingUserId)) return;
+            if (string.IsNullOrEmpty(callingUserId))
+            {
+                Console.WriteLine("SendAnswer failed: CallingUserId is null or empty");
+                throw new HubException("CallingUserId is null or empty");
+            }
 
-            var targetConnectionId = ConnectionToUserMap.FirstOrDefault(kvp => kvp.Value == targetuserId).Key;
+            if (string.IsNullOrEmpty(targetUserId) || string.IsNullOrEmpty(serializedAnswer))
+            {
+                Console.WriteLine($"SendAnswer failed: Invalid parameters - targetUserId: {targetUserId}, serializedAnswer: {serializedAnswer}");
+                throw new HubException($"Invalid parameters - targetUserId: {targetUserId}, serializedAnswer: {serializedAnswer}");
+            }
+
+            var targetConnectionId = ConnectionToUserMap.FirstOrDefault(kvp => kvp.Value == targetUserId).Key;
             if (!string.IsNullOrEmpty(targetConnectionId))
             {
-                await Clients.Client(targetConnectionId).SendAsync("ReceiveAnswer", answer);
-                Console.WriteLine($"Answer sent from {callingUserId} to {targetuserId}");
+                await Clients.Client(targetConnectionId).SendAsync("ReceiveAnswer", serializedAnswer);
+                Console.WriteLine($"Answer sent from {callingUserId} to {targetUserId}: {serializedAnswer}");
+            }
+            else
+            {
+                Console.WriteLine($"SendAnswer failed: No connection found for targetUserId: {targetUserId}");
+                throw new HubException($"No connection found for targetUserId: {targetUserId}");
             }
         }
 
-        public async Task SendIceCandidate(string targetuserId, object candidate)
+        public async Task SendIceCandidate(string targetUserId, string candidate)
         {
             var callingUserId = Context?.User?.FindFirstValue(ClaimTypes.NameIdentifier);
-            if (string.IsNullOrEmpty(callingUserId)) return;
+            if (string.IsNullOrEmpty(callingUserId))
+            {
+                Console.WriteLine("SendIceCandidate failed: CallingUserId is null or empty");
+                throw new HubException("CallingUserId is null or empty");
+            }
 
-            var targetConnectionId = ConnectionToUserMap.FirstOrDefault(kvp => kvp.Value == targetuserId).Key;
+            if (string.IsNullOrEmpty(targetUserId) || string.IsNullOrEmpty(candidate))
+            {
+                Console.WriteLine($"SendIceCandidate failed: Invalid parameters - targetUserId: {targetUserId}, candidate: {candidate}");
+                throw new HubException($"Invalid parameters - targetUserId: {targetUserId}, candidate: {candidate}");
+            }
+
+            try
+            {
+                // Gelen candidate string'inin geçerli bir JSON olup olmadığını kontrol et
+                System.Text.Json.JsonDocument.Parse(candidate);
+            }
+            catch (System.Text.Json.JsonException ex)
+            {
+                Console.WriteLine($"SendIceCandidate failed: Invalid candidate JSON - {ex.Message}");
+                throw new HubException($"Invalid candidate JSON: {ex.Message}");
+            }
+
+            var targetConnectionId = ConnectionToUserMap.FirstOrDefault(kvp => kvp.Value == targetUserId).Key;
             if (!string.IsNullOrEmpty(targetConnectionId))
             {
                 await Clients.Client(targetConnectionId).SendAsync("ReceiveIceCandidate", candidate);
-                Console.WriteLine($"ICE candidate sent from {callingUserId} to {targetuserId}");
+                Console.WriteLine($"ICE candidate sent from {callingUserId} to {targetUserId}: {candidate}");
+            }
+            else
+            {
+                Console.WriteLine($"SendIceCandidate failed: No connection found for targetUserId: {targetUserId}");
+                throw new HubException($"No connection found for targetUserId: {targetUserId}");
             }
         }
     }


### PR DESCRIPTION
This pull request introduces several improvements to the VidSync API and signaling hub, focusing on enhanced error handling, expanded CORS support, server configuration, and developer tooling. The most significant changes involve more robust validation and error reporting in the `CommunicationHub`, expanded CORS origins for local and network development, and updates to server listening settings for both HTTP and HTTPS.

**Signaling and API robustness improvements:**

* Enhanced error handling and validation in `CommunicationHub` methods (`JoinRoom`, `SendOffer`, `SendAnswer`, `SendIceCandidate`), including detailed logging and specific exceptions for invalid input or missing users/connections. Additionally, input parameters are now validated, and ICE candidates are checked for valid JSON. (`[[1]](diffhunk://#diff-9eb8ccec08defaf24de0b218fe1940c46b6c6c412c6221a0574953cd98ea8b59L25-R44)`, `[[2]](diffhunk://#diff-9eb8ccec08defaf24de0b218fe1940c46b6c6c412c6221a0574953cd98ea8b59L48-R64)`, `[[3]](diffhunk://#diff-9eb8ccec08defaf24de0b218fe1940c46b6c6c412c6221a0574953cd98ea8b59L75-R180)`)
* Added a simple `TestController` with a GET endpoint to verify API availability. (`[src/Core/VidSync.API/Controllers/TestController.csR1-R16](diffhunk://#diff-4d5039f90b95c0a2eb5c0d91360783036bfd12fd2da557f1d7171cb2a2aa2c34R1-R16)`)

**Configuration and environment improvements:**

* Expanded CORS policy in `Program.cs` to allow requests from both localhost and specific LAN IP addresses, supporting both HTTP and HTTPS for local development. (`[src/Core/VidSync.API/Program.csR10-R29](diffhunk://#diff-7d0380fe0bf9dd3d8b4cc022af34a89d2244a85038671c7604b41d01d3954284R10-R29)`)
* Configured Kestrel to listen on all interfaces for both HTTP (port 5123) and HTTPS (port 7123) with a specified certificate, improving deployment flexibility. (`[src/Core/VidSync.API/Program.csL89-R111](diffhunk://#diff-7d0380fe0bf9dd3d8b4cc022af34a89d2244a85038671c7604b41d01d3954284L89-R111)`)
* Updated `launchSettings.json` to include multiple URLs (HTTP and HTTPS) for local development, matching the new server configuration. (`[src/Core/VidSync.API/Properties/launchSettings.jsonL8-R8](diffhunk://#diff-4987b672affc8609adfeb26a75e8905ea90a328f9d8b5cc11b0b60e33bfdf95dL8-R8)`)

**Minor codebase maintenance:**

* Added missing `using System.Threading.Tasks;` directive in `CommunicationHub.cs` for async support. (`[src/Core/VidSync.Signaling/Hubs/CommunicationHub.csR7](diffhunk://#diff-9eb8ccec08defaf24de0b218fe1940c46b6c6c412c6221a0574953cd98ea8b59R7)`)
* Minor cleanup in `Program.cs` to streamline middleware order. (`[src/Core/VidSync.API/Program.csL104-L109](diffhunk://#diff-7d0380fe0bf9dd3d8b4cc022af34a89d2244a85038671c7604b41d01d3954284L104-L109)`)