### PR TITLE
Sprint3 - Messaging Infrastructure Established

### DIFF
--- a/src/Core/VidSync.API/DTOs/MessageDto.cs
+++ b/src/Core/VidSync.API/DTOs/MessageDto.cs
@@ -1,0 +1,11 @@
+namespace VidSync.API.DTOs;
+
+public class MessageDto
+{
+    public Guid Id { get; set; }
+    public Guid RoomId { get; set; }
+    public Guid SenderId { get; set; }
+    public string Content { get; set; } = null!;
+    public DateTime SentAt { get; set; }
+    public string SenderName { get; set; } = null!;
+}

--- a/src/Core/VidSync.Signaling/VidSync.Signaling.csproj
+++ b/src/Core/VidSync.Signaling/VidSync.Signaling.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Domain\VidSync.Domain\VidSync.Domain.csproj" />
+    <ProjectReference Include="..\..\Infrastructure\VidSync.Persistence\VidSync.Persistence.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request introduces a new real-time messaging feature to the signaling hub, enabling users to send and receive messages in rooms. It adds a new DTO for messages, updates the hub to persist and broadcast messages, and includes necessary infrastructure dependencies.

**Messaging feature implementation:**

* Added a new `MessageDto` class in `VidSync.API.DTOs` to define the data structure for messages, including sender information and timestamps.
* Implemented a `SendMessage` method in `CommunicationHub` that saves messages to the database and broadcasts them to all users in the room, including sender details.
* Injected `AppDbContext` into `CommunicationHub` to enable message persistence and user lookup.
* Added a project reference to `VidSync.Persistence` in the signaling project to support database operations.

**Code quality and minor improvements:**

* Improved group management by ensuring users are properly removed from SignalR groups on disconnect.
* Cleaned up comments in the ICE candidate handling logic for clarity.