### PR TITLE
Add Docker support for VidSync API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# *.pfx
+# .certs/
+
+[Bb]in/
+[Oo]bj/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # Environments
 .env
 *.local
+.certs/
 
 # App settings
 src/Core/VidSync.API/appsettings.Development.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Stage 1: Build aplication
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /app
+
+# NuGet paketlerini optimize etmek için önce proje dosyalarını kopyala
+COPY *.sln .
+COPY src/Core/VidSync.API/*.csproj ./src/Core/VidSync.API/
+COPY src/Core/VidSync.Signaling/*.csproj ./src/Core/VidSync.Signaling/
+COPY src/Domain/VidSync.Domain/*.csproj ./src/Domain/VidSync.Domain/
+COPY src/Infrastructure/VidSync.Persistence/*.csproj ./src/Infrastructure/VidSync.Persistence/
+
+RUN dotnet restore
+
+COPY . .
+
+WORKDIR /app/src/Core/VidSync.API
+RUN dotnet publish -c Release -o /app/publish --no-restore
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+
+COPY --from=build /app/publish .
+
+EXPOSE 5123
+EXPOSE 7123
+
+ENTRYPOINT ["dotnet", "VidSync.API.dll"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,23 @@
 services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: vidsync_api
+    ports:
+      - "7123:7123" # HTTPS
+      - "5123:5123" # HTTP
+    environment:
+      - ASPNETCORE_URLS=https://+:7123;http://+:5123
+      - ConnectionStrings__DefaultConnection=Host=db;Port=5432;Database=${DB_NAME};Username=${DB_USER};Password=${DB_PASSWORD}
+      - ConnectionStrings__Redis=redis:6379
+    volumes:
+      - ./src/Core/VidSync.API/localhost+3.p12:/app/localhost+3.p12:ro
+    depends_on:
+      - db
+      - redis
+    restart: unless-stopped
+
   db:
     image: postgres:15
     container_name: vidsync_db


### PR DESCRIPTION
Introduced Dockerfile and .dockerignore for building and running the VidSync API in containers. Updated docker-compose.yml to define services for the API, database, and Redis, including environment variables and volume mappings. Updated .gitignore to exclude .certs/ directory.