### PR TITLE
Add TranscriptionHub and update SignalR endpoints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,9 +45,7 @@ services:
     image: cloudflare/cloudflared:latest
     container_name: vidsync_cloudflared
     restart: unless-stopped
-    command: tunnel run vidsync-tunnel
-    volumes:
-      - ./cloudflared:/etc/cloudflared
+    command: tunnel run --token ${CLOUDFLARE_TUNNEL_TOKEN}
     depends_on:
       - api
 

--- a/src/Core/VidSync.API/Program.cs
+++ b/src/Core/VidSync.API/Program.cs
@@ -26,12 +26,15 @@ builder.Services.AddCors(options =>
                       {
                             policy.WithOrigins(
                                 // Localhost adresleri
-                                "http://localhost:5173", 
+                                "http://localhost:5173",
                                 "https://localhost:5173",
 
                                 // IP adresleri
                                 "http://192.168.1.157:5173",
-                                "https://192.168.1.157:5173"
+                                "https://192.168.1.157:5173",
+
+                                // Üretim domain adresleri
+                                "https://vidsync-front.enesefetokta.shop"
                               )
                                 .AllowAnyHeader()
                                 .AllowAnyMethod()
@@ -148,6 +151,8 @@ app.UseCors(MyAllowSpecificOrigins);
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
+
 app.MapHub<CommunicationHub>("/communicationhub");
+app.MapHub<TranscriptionHub>("/transcriptionhub");
 
 app.Run();

--- a/src/Core/VidSync.Signaling/Hubs/TranscriptionHub.cs
+++ b/src/Core/VidSync.Signaling/Hubs/TranscriptionHub.cs
@@ -1,0 +1,37 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace VidSync.Signaling.Hubs;
+
+[Authorize]
+public class TranscriptionHub : Hub
+{
+    public async Task JoinSession(string sessionId)
+    {
+        await Groups.AddToGroupAsync(Context.ConnectionId, sessionId);
+        Console.WriteLine($"Client {Context.ConnectionId} joined transcription session {sessionId}");
+    }
+
+    public async Task StreamAudio(IAsyncEnumerable<byte[]> stream, string sessionId)
+    {
+        var userId = Context.User?.FindFirstValue(ClaimTypes.NameIdentifier);
+        Console.WriteLine($"User {userId} started streaming audio for session {sessionId}");
+
+        try
+        {
+            await foreach (var audioChunk in stream)
+            {
+                Console.WriteLine($"Received audio chunk of size {audioChunk.Length} from user {userId}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error during audio streaming for user {userId}: {ex.Message}");
+        }
+        finally
+        {
+            Console.WriteLine($"User {userId} stopped streaming audio for session {sessionId}");
+        }
+    }
+}


### PR DESCRIPTION
Introduced TranscriptionHub for handling transcription sessions via SignalR. Updated Program.cs to map the new hub endpoint and added production domain to CORS policy. Modified docker-compose.yml to use CLOUDFLARE_TUNNEL_TOKEN for cloudflared tunnel configuration.